### PR TITLE
Add Python37 to PyPI Classifiers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ TODO
 - CFB red black tree
 - XML support
 
-.. |python-versions| image:: https://img.shields.io/badge/python-2.7%2C%203.5%2C%203.6-blue.svg
+.. |python-versions| image:: https://img.shields.io/badge/python-2.7%2C%203.5%2C%203.6%2C%203.7-blue.svg
 
 .. |travis-build| image:: https://travis-ci.org/markreidvfx/pyaaf2.svg?branch=master
     :alt: travis build status

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import sys
 import os
 from setuptools import setup
 import setuptools.command.build_py
@@ -65,6 +64,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Operating System :: OS Independent',
         'Natural Language :: English',
     ],


### PR DESCRIPTION
Goal:

[VFX Reference Platform CY2020](https://vfxplatform.com/) targets Python 3.7.X and the distribution on PyPI only lists Python 3.6.

I have run all tests inside of a Python37 virtual environment and they have all passed.

![image](https://user-images.githubusercontent.com/3489076/59816755-2ef36000-92d2-11e9-93d5-aee321474904.png)
