### PR TITLE
Default Length of 0 for pcm audio descriptor

### DIFF
--- a/aaf2/mxf.py
+++ b/aaf2/mxf.py
@@ -689,8 +689,9 @@ class MXFPCMDescriptor(MXFDescriptor):
         d = self.create_aaf_instance()
         # required
         for key in ('BlockAlign', 'AverageBPS', 'Channels',
-            'QuantizationBits', 'AudioSamplingRate', 'SampleRate', 'Length'):
+            'QuantizationBits', 'AudioSamplingRate', 'SampleRate'):
             d[key].value = self.data[key]
+        d['Length'].value = self.data.get('Length', 0)
         n = self.root.aaf.create.NetworkLocator()
         n['URLString'].value = ama_path(self.root.path)
         d['Locator'].append(n)


### PR DESCRIPTION
I have some aaf files containing references to pcm audio of Length 0 but they are missing the Length entry in the pcm audio descriptor altogether. I have added a default of 0 when this is the case. I don't think this can break anything as Length is always required.