### PR TITLE
Allow including offlined media in AAF

### DIFF
--- a/aaf2/components.py
+++ b/aaf2/components.py
@@ -15,6 +15,7 @@ class Component(core.AAFObject):
     class_id = AUID("0d010101-0101-0200-060e-2b3402060101")
     __slots__ = ()
     def __init__(self, media_kind=None, length=None):
+        super(Component, self).__init__()
         self.media_kind = media_kind or 'picture'
         self.length = length or 0
 
@@ -48,10 +49,17 @@ class Segment(Component):
     class_id = AUID("0d010101-0101-0300-060e-2b3402060101")
     __slots__ = ()
 
+    def __init__(self, media_kind=None, length=None):
+        super(Segment, self).__init__(media_kind=media_kind, length=length)
+
+
 @register_class
 class Transition(Component):
     class_id = AUID("0d010101-0101-1700-060e-2b3402060101")
     __slots__ = ()
+
+    def __init__(self, media_kind=None, length=None):
+        super(Transition, self).__init__(media_kind=media_kind, length=length)
 
     @property
     def cutpoint(self):
@@ -65,6 +73,9 @@ class Transition(Component):
 class Sequence(Segment):
     class_id = AUID("0d010101-0101-0f00-060e-2b3402060101")
     __slots__ = ()
+
+    def __init__(self, media_kind=None, length=None):
+        super(Sequence, self).__init__(media_kind=media_kind, length=length)
 
     @property
     def components(self):
@@ -113,6 +124,9 @@ class NestedScope(Segment):
     class_id = AUID("0d010101-0101-0b00-060e-2b3402060101")
     __slots__ = ()
 
+    def __init__(self, media_kind=None, length=None):
+        super(NestedScope, self).__init__(media_kind=media_kind, length=length)
+
     @property
     def slots(self):
         return self['Slots']
@@ -120,6 +134,9 @@ class NestedScope(Segment):
 class SourceReference(Segment):
     class_id = AUID("0d010101-0101-1000-060e-2b3402060101")
     __slots__ = ()
+
+    def __init__(self, media_kind=None, length=None):
+        super(SourceReference, self).__init__(media_kind=media_kind, length=length)
 
     @property
     def mob_id(self):
@@ -223,38 +240,62 @@ class Filler(Segment):
     class_id = AUID("0d010101-0101-0900-060e-2b3402060101")
     __slots__ = ()
 
+    def __init__(self, media_kind=None, length=None):
+        super(Filler, self).__init__(media_kind=media_kind, length=length)
+
+
 @register_class
 class EssenceGroup(Segment):
     class_id = AUID("0d010101-0101-0500-060e-2b3402060101")
     __slots__ = ()
+
+    def __init__(self, media_kind=None, length=None):
+        super(EssenceGroup, self).__init__(media_kind=media_kind, length=length)
+
 
 @register_class
 class EdgeCode(Segment):
     class_id = AUID("0d010101-0101-0400-060e-2b3402060101")
     __slots__ = ()
 
+    def __init__(self, media_kind=None, length=None):
+        super(EdgeCode, self).__init__(media_kind=media_kind, length=length)
+
+
 @register_class
 class Pulldown(Segment):
     class_id = AUID("0d010101-0101-0c00-060e-2b3402060101")
     __slots__ = ()
+
+    def __init__(self, media_kind=None, length=None):
+        super(Pulldown, self).__init__(media_kind=media_kind, length=length)
+
 
 @register_class
 class ScopeReference(Segment):
     class_id = AUID("0d010101-0101-0d00-060e-2b3402060101")
     __slots__ = ()
 
+    def __init__(self, media_kind=None, length=None):
+        super(ScopeReference, self).__init__(media_kind=media_kind, length=length)
+
+
 @register_class
 class Selector(Segment):
     class_id = AUID("0d010101-0101-0e00-060e-2b3402060101")
     __slots__ = ()
+
+    def __init__(self, media_kind=None, length=None):
+        super(Selector, self).__init__(media_kind=media_kind, length=length)
+
 
 @register_class
 class Timecode(Segment):
     class_id = AUID("0d010101-0101-1400-060e-2b3402060101")
     __slots__ = ()
 
-    def __init__(self, fps=25, drop=False):
-        length = fps * 60 * 60 * 12 # 12 hours
+    def __init__(self, fps=25, drop=False, length=None):
+        length = length or fps * 60 * 60 * 12  # 12 hours
         super(Timecode, self).__init__(length=length, media_kind='Timecode')
         self.start = 0
         self.fps = fps
@@ -289,10 +330,12 @@ class OperationGroup(Segment):
     class_id = AUID("0d010101-0101-0a00-060e-2b3402060101")
     __slots__ = ()
 
-    def __init__(self, operationdef, length=None):
-        super(OperationGroup, self).__init__(length=length)
+    def __init__(self, operationdef, length=None, media_kind=None):
+        super(OperationGroup, self).__init__(media_kind=media_kind, length=length)
         self.operation = self.root.dictionary.lookup_operationdef(operationdef)
-        self.media_kind = self.operation.media_kind
+
+        if self.media_kind is None:
+            self.media_kind = self.operation.media_kind
 
     @property
     def operation(self):
@@ -322,7 +365,14 @@ class CommentMarker(Event):
     class_id = AUID("0d010101-0101-0800-060e-2b3402060101")
     __slots__ = ()
 
+    def __init__(self):
+        super(CommentMarker, self).__init__()
+
+
 @register_class
 class DescriptiveMarker(CommentMarker):
     class_id = AUID("0d010101-0101-4100-060e-2b3402060101")
     __slots__ = ()
+
+    def __init__(self):
+        super(DescriptiveMarker, self).__init__()

--- a/aaf2/components.py
+++ b/aaf2/components.py
@@ -52,17 +52,10 @@ class Segment(Component):
     class_id = AUID("0d010101-0101-0300-060e-2b3402060101")
     __slots__ = ()
 
-    def __init__(self, media_kind=None, length=None):
-        super(Segment, self).__init__(media_kind=media_kind, length=length)
-
-
 @register_class
 class Transition(Component):
     class_id = AUID("0d010101-0101-1700-060e-2b3402060101")
     __slots__ = ()
-
-    def __init__(self, media_kind=None, length=None):
-        super(Transition, self).__init__(media_kind=media_kind, length=length)
 
     @property
     def cutpoint(self):
@@ -77,9 +70,6 @@ class Transition(Component):
 class Sequence(Segment):
     class_id = AUID("0d010101-0101-0f00-060e-2b3402060101")
     __slots__ = ()
-
-    def __init__(self, media_kind=None, length=None):
-        super(Sequence, self).__init__(media_kind=media_kind, length=length)
 
     @property
     def components(self):
@@ -128,9 +118,6 @@ class NestedScope(Segment):
     class_id = AUID("0d010101-0101-0b00-060e-2b3402060101")
     __slots__ = ()
 
-    def __init__(self, media_kind=None, length=None):
-        super(NestedScope, self).__init__(media_kind=media_kind, length=length)
-
     @property
     def slots(self):
         return self['Slots']
@@ -139,9 +126,6 @@ class NestedScope(Segment):
 class SourceReference(Segment):
     class_id = AUID("0d010101-0101-1000-060e-2b3402060101")
     __slots__ = ()
-
-    def __init__(self, media_kind=None, length=None):
-        super(SourceReference, self).__init__(media_kind=media_kind, length=length)
 
     @property
     def mob_id(self):
@@ -247,54 +231,30 @@ class Filler(Segment):
     class_id = AUID("0d010101-0101-0900-060e-2b3402060101")
     __slots__ = ()
 
-    def __init__(self, media_kind=None, length=None):
-        super(Filler, self).__init__(media_kind=media_kind, length=length)
-
-
 @register_class
 class EssenceGroup(Segment):
     class_id = AUID("0d010101-0101-0500-060e-2b3402060101")
     __slots__ = ()
-
-    def __init__(self, media_kind=None, length=None):
-        super(EssenceGroup, self).__init__(media_kind=media_kind, length=length)
-
 
 @register_class
 class EdgeCode(Segment):
     class_id = AUID("0d010101-0101-0400-060e-2b3402060101")
     __slots__ = ()
 
-    def __init__(self, media_kind=None, length=None):
-        super(EdgeCode, self).__init__(media_kind=media_kind, length=length)
-
-
 @register_class
 class Pulldown(Segment):
     class_id = AUID("0d010101-0101-0c00-060e-2b3402060101")
     __slots__ = ()
-
-    def __init__(self, media_kind=None, length=None):
-        super(Pulldown, self).__init__(media_kind=media_kind, length=length)
-
 
 @register_class
 class ScopeReference(Segment):
     class_id = AUID("0d010101-0101-0d00-060e-2b3402060101")
     __slots__ = ()
 
-    def __init__(self, media_kind=None, length=None):
-        super(ScopeReference, self).__init__(media_kind=media_kind, length=length)
-
-
 @register_class
 class Selector(Segment):
     class_id = AUID("0d010101-0101-0e00-060e-2b3402060101")
     __slots__ = ()
-
-    def __init__(self, media_kind=None, length=None):
-        super(Selector, self).__init__(media_kind=media_kind, length=length)
-
 
 @register_class
 class Timecode(Segment):
@@ -379,14 +339,7 @@ class CommentMarker(Event):
     class_id = AUID("0d010101-0101-0800-060e-2b3402060101")
     __slots__ = ()
 
-    def __init__(self):
-        super(CommentMarker, self).__init__()
-
-
 @register_class
 class DescriptiveMarker(CommentMarker):
     class_id = AUID("0d010101-0101-4100-060e-2b3402060101")
     __slots__ = ()
-
-    def __init__(self):
-        super(DescriptiveMarker, self).__init__()

--- a/aaf2/components.py
+++ b/aaf2/components.py
@@ -11,9 +11,11 @@ from . mobid import MobID
 from . dictionary import DataDef
 from .auid import AUID
 
+
 class Component(core.AAFObject):
     class_id = AUID("0d010101-0101-0200-060e-2b3402060101")
     __slots__ = ()
+
     def __init__(self, media_kind=None, length=None):
         super(Component, self).__init__()
         self.media_kind = media_kind or 'picture'
@@ -45,6 +47,7 @@ class Component(core.AAFObject):
     def media_kind(self, value):
         self.datadef = self.root.dictionary.lookup_datadef(value)
 
+
 class Segment(Component):
     class_id = AUID("0d010101-0101-0300-060e-2b3402060101")
     __slots__ = ()
@@ -69,6 +72,7 @@ class Transition(Component):
     def cutpoint(self, value):
         self['CutPoint'].value = value
 
+
 @register_class
 class Sequence(Segment):
     class_id = AUID("0d010101-0101-0f00-060e-2b3402060101")
@@ -85,7 +89,6 @@ class Sequence(Segment):
         return self.components[self.index_at_time(edit_unit)]
 
     def index_at_time(self, edit_unit):
-
         last_component = None
         last_index = None
 
@@ -96,7 +99,7 @@ class Sequence(Segment):
         for index, position, component in self.positions():
 
             if isinstance(component, Transition):
-                if edit_unit >= position and edit_unit < position + component.length:
+                if position <= edit_unit < position + component.length:
                     return index
 
             # gone past return previous
@@ -119,6 +122,7 @@ class Sequence(Segment):
                 yield (index, length, component)
                 length += component.length
 
+
 @register_class
 class NestedScope(Segment):
     class_id = AUID("0d010101-0101-0b00-060e-2b3402060101")
@@ -130,6 +134,7 @@ class NestedScope(Segment):
     @property
     def slots(self):
         return self['Slots']
+
 
 class SourceReference(Segment):
     class_id = AUID("0d010101-0101-1000-060e-2b3402060101")
@@ -176,6 +181,7 @@ class SourceReference(Segment):
     @slot.setter
     def slot(self, value):
         self.slot_id = value.slot_id
+
 
 @register_class
 class SourceClip(SourceReference):
@@ -234,6 +240,7 @@ class SourceClip(SourceReference):
         else:
             raise NotImplementedError("Walking {} not implemented".format(
                                       type(segment)))
+
 
 @register_class
 class Filler(Segment):
@@ -325,6 +332,7 @@ class Timecode(Segment):
     def drop(self, value):
         self['Drop'].value = value
 
+
 @register_class
 class OperationGroup(Segment):
     class_id = AUID("0d010101-0101-0a00-060e-2b3402060101")
@@ -357,12 +365,14 @@ class OperationGroup(Segment):
     def segments(self):
         return self['InputSegments']
 
+
 class Event(Segment):
     class_id = AUID("0d010101-0101-0600-060e-2b3402060101")
     __slots__ = ()
 
     def __init__(self):
         super(Event, self).__init__(media_kind='DescriptiveMetadata')
+
 
 @register_class
 class CommentMarker(Event):

--- a/aaf2/components.py
+++ b/aaf2/components.py
@@ -349,6 +349,10 @@ class OperationGroup(Segment):
     def parameters(self):
         return self['Parameters']
 
+    @parameters.setter
+    def parameters(self, value):
+        self['Parameters'] = value
+
     @property
     def segments(self):
         return self['InputSegments']

--- a/aaf2/core.py
+++ b/aaf2/core.py
@@ -68,7 +68,7 @@ class AAFObject(object):
 
     @property
     def unique_key(self):
-        self.unique_property.value
+        return self.unique_property.value
 
     def read_properties(self):
         stream = self.dir.get('properties')

--- a/aaf2/core.py
+++ b/aaf2/core.py
@@ -30,6 +30,7 @@ P_HEADER_STRUCT = struct.Struct(str('<BBH'))
 
 OPERATIONGROUP_PARAMETERS_AUID = AUID("06010104-060a-0000-060e-2b3401010102")
 
+
 class AAFObject(object):
     __slots__ = ('class_id', 'root', 'dir', 'property_entries', '__weakref__' )
 
@@ -177,7 +178,6 @@ class AAFObject(object):
                 # print('writing index', self, p)
                 p.write_index()
 
-
     def detach(self, delete=False):
         items = []
         for item, streams in self.walk_references(topdown=True):
@@ -228,7 +228,6 @@ class AAFObject(object):
                 p.attach()
 
     def walk_references(self, topdown=False):
-
         refs = []
         streams = []
         for p in self.properties():
@@ -298,7 +297,7 @@ class AAFObject(object):
         for item in self.properties():
             if item.name == key:
                 return item
-        if allkeys == False:
+        if not allkeys:
             return default
 
         classdef = self.classdef
@@ -318,7 +317,7 @@ class AAFObject(object):
         return default
 
     def getvalue(self, key, default=None):
-        if not key in self.keys():
+        if key not in self.keys():
             return default
 
         p = self.get(key, None)
@@ -349,7 +348,7 @@ class AAFObject(object):
 
     def __repr__(self):
         s = "%s.%s" % (self.__class__.__module__,
-                                self.__class__.__name__)
+                       self.__class__.__name__)
         name = self.name
         if name:
             s += ' %s' % name
@@ -357,7 +356,6 @@ class AAFObject(object):
         return '<%s at 0x%x>' % (s, id(self))
 
     def dump(self, space=""):
-
         indent = "  "
 
         for p in self.properties():

--- a/aaf2/dictionary.py
+++ b/aaf2/dictionary.py
@@ -132,6 +132,15 @@ class OperationDef(DefinitionObject):
     def parameters(self):
         return self['ParametersDefined']
 
+    @property
+    def number_inputs(self):
+        return self['NumberInputs'].value
+
+    @number_inputs.setter
+    def number_inputs(self, value):
+        self['NumberInputs'].value = value
+
+
 @register_class
 class ParameterDef(DefinitionObject):
     class_id = AUID("0d010101-0101-1d00-060e-2b3402060101")

--- a/aaf2/file.py
+++ b/aaf2/file.py
@@ -39,7 +39,6 @@ class AAFFactory(object):
         return self.create_instance
 
     def from_name(self, name, *args, **kwargs):
-
         classdef = self.root.metadict.lookup_classdef(name)
         if classdef is None:
             raise ValueError("no class found with name: %s" % name)

--- a/aaf2/misc.py
+++ b/aaf2/misc.py
@@ -385,9 +385,14 @@ class VaryingValue(Parameter):
     @property
     def interpolation(self):
         return self['Interpolation'].value
-    @interpolationdef.setter
+
+    @interpolation.setter
     def interpolation(self, value):
         self['Interpolation'].value = value
+
+    @property
+    def pointlist(self):
+        return self['PointList']
 
     @property
     def typedef(self):

--- a/aaf2/misc.py
+++ b/aaf2/misc.py
@@ -362,10 +362,12 @@ def generate_offset_map(speed_map, start=0, end=None):
 
     return result
 
+
 @register_class
 class VaryingValue(Parameter):
     class_id = AUID("0d010101-0101-3e00-060e-2b3402060101")
     __slots__ = ()
+
     def __init__(self, parameterdef=None, interperlationdef=None):
         super(VaryingValue, self).__init__()
         if parameterdef:
@@ -377,6 +379,7 @@ class VaryingValue(Parameter):
     @property
     def interpolationdef(self):
         return self['Interpolation'].value
+
     @interpolationdef.setter
     def interpolationdef(self, value):
         self['Interpolation'].value = value
@@ -542,7 +545,7 @@ class ControlPoint(core.AAFObject):
 
     @value.setter
     def value(self, value):
-        self['Value'].value =  AAFRational(value)
+        self['Value'].value = AAFRational(value)
 
     @property
     def point_properties(self):

--- a/aaf2/mobs.py
+++ b/aaf2/mobs.py
@@ -18,6 +18,7 @@ from . import audio
 from .rational import AAFRational
 from .auid import AUID
 
+
 @register_class
 class Mob(core.AAFObject):
     """
@@ -65,6 +66,7 @@ class Mob(core.AAFObject):
     @property
     def usage(self):
         return self['UsageCode'].value
+
     @usage.setter
     def usage(self, value):
         self['UsageCode'].value = value
@@ -151,6 +153,7 @@ class Mob(core.AAFObject):
 
         return '<%s at 0x%x>' % (s, id(self))
 
+
 @register_class
 class CompositionMob(Mob):
     class_id = AUID("0d010101-0101-3500-060e-2b3402060101")
@@ -208,6 +211,7 @@ class MasterMob(Mob):
         slot.segment.length = source_slot.segment.length
         return slot
 
+
 @register_class
 class SourceMob(Mob):
     class_id = AUID("0d010101-0101-3700-060e-2b3402060101")
@@ -219,6 +223,7 @@ class SourceMob(Mob):
     @property
     def descriptor(self):
         return self['EssenceDescription'].value
+
     @descriptor.setter
     def descriptor(self, value):
         self['EssenceDescription'].value = value

--- a/aaf2/mobs.py
+++ b/aaf2/mobs.py
@@ -184,7 +184,7 @@ class MasterMob(Mob):
         slot.segment.length = source_slot.segment.length
         return slot
 
-    def import_audio_essence(self, path, edit_rate=None, tape=None):
+    def import_audio_essence(self, path, edit_rate=None, tape=None, length=None, offline=False):
         """
         Import audio essence from wav file
         """
@@ -193,7 +193,7 @@ class MasterMob(Mob):
         source_mob = self.root.create.SourceMob("%s.PHYS" % self.name)
         self.root.content.mobs.append(source_mob)
 
-        source_slot = source_mob.import_audio_essence(path, edit_rate, tape)
+        source_slot = source_mob.import_audio_essence(path, edit_rate, tape, length, offline)
 
         # create slot and clip that references source_mob slot
         edit_rate = edit_rate or source_slot.edit_rate
@@ -354,7 +354,7 @@ class SourceMob(Mob):
 
         return slot
 
-    def import_audio_essence(self, path, edit_rate=None, tape=None):
+    def import_audio_essence(self, path, edit_rate=None, tape=None, length=None, offline=False):
         """
         Import audio essence from wav file
         """
@@ -365,12 +365,12 @@ class SourceMob(Mob):
         channels = a.getnchannels()
         sample_width = a.getsampwidth()
         block_align = a.getblockalign()
-        length = a.getnframes()
+        frames = a.getnframes()
 
         edit_rate = edit_rate or sample_rate
 
         # create essencedata
-        essencedata, slot = self.create_essence(edit_rate, 'sound')
+        essencedata, slot = self.create_essence(edit_rate, 'sound', offline=offline)
         if tape:
             slot.segment = tape
 
@@ -385,16 +385,17 @@ class SourceMob(Mob):
         descriptor['AudioSamplingRate'].value = sample_rate
 
         # set lengths
-        descriptor.length = length
-        slot.segment.length = int(rescale(length, sample_rate, edit_rate))
+        descriptor.length = frames
+        slot.segment.length = length or int(rescale(frames, sample_rate, edit_rate))
 
-        stream = essencedata.open('w')
+        if essencedata is not None:
+            stream = essencedata.open('w')
 
-        while True:
-            data = a.readframes(sample_rate)
-            if not data:
-                break
-            stream.write(data)
+            while True:
+                data = a.readframes(sample_rate)
+                if not data:
+                    break
+                stream.write(data)
 
         return slot
 

--- a/aaf2/mobs.py
+++ b/aaf2/mobs.py
@@ -159,17 +159,10 @@ class CompositionMob(Mob):
     class_id = AUID("0d010101-0101-3500-060e-2b3402060101")
     __slots__ = ()
 
-    def __init__(self, name=None):
-        super(CompositionMob, self).__init__(name)
-
-
 @register_class
 class MasterMob(Mob):
     class_id = AUID("0d010101-0101-3600-060e-2b3402060101")
     __slots__ = ()
-
-    def __init__(self, name=None):
-        super(MasterMob, self).__init__(name)
 
     def import_dnxhd_essence(self, path, edit_rate, tape=None, length=None, offline=False):
         """
@@ -216,9 +209,6 @@ class MasterMob(Mob):
 class SourceMob(Mob):
     class_id = AUID("0d010101-0101-3700-060e-2b3402060101")
     __slots__ = ()
-
-    def __init__(self, name=None):
-        super(SourceMob, self).__init__(name)
 
     @property
     def descriptor(self):

--- a/aaf2/mobslots.py
+++ b/aaf2/mobslots.py
@@ -82,6 +82,9 @@ class EventMobSlot(MobSlot):
     class_id = AUID( "0d010101-0101-3900-060e-2b3402060101")
     __slots__ = ()
 
+    def __init__(self, slot_id=None, name=None, segment=None):
+        super(EventMobSlot, self).__init__(slot_id=slot_id, name=name, segment=segment)
+
     @property
     def edit_rate(self):
         return self['EditRate'].value

--- a/aaf2/mobslots.py
+++ b/aaf2/mobslots.py
@@ -84,9 +84,6 @@ class EventMobSlot(MobSlot):
     class_id = AUID( "0d010101-0101-3900-060e-2b3402060101")
     __slots__ = ()
 
-    def __init__(self, slot_id=None, name=None, segment=None):
-        super(EventMobSlot, self).__init__(slot_id=slot_id, name=name, segment=segment)
-
     @property
     def edit_rate(self):
         return self['EditRate'].value

--- a/aaf2/mobslots.py
+++ b/aaf2/mobslots.py
@@ -10,6 +10,7 @@ from .utils import register_class
 from .auid import AUID
 from . import components
 
+
 @register_class
 class MobSlot(core.AAFObject):
     class_id = AUID("0d010101-0101-3800-060e-2b3402060101")
@@ -77,6 +78,7 @@ class MobSlot(core.AAFObject):
     def length(self):
         return 0
 
+
 @register_class
 class EventMobSlot(MobSlot):
     class_id = AUID( "0d010101-0101-3900-060e-2b3402060101")
@@ -93,10 +95,12 @@ class EventMobSlot(MobSlot):
     def edit_rate(self, value):
         self['EditRate'].value = value
 
+
 @register_class
 class TimelineMobSlot(MobSlot):
     class_id = AUID("0d010101-0101-3b00-060e-2b3402060101")
     __slots__ = ()
+
     def __init__(self, slot_id=None, name=None, segment=None, origin=None, edit_rate=None):
         super(TimelineMobSlot, self).__init__(slot_id, name, segment)
         self.origin = origin or 0
@@ -105,6 +109,7 @@ class TimelineMobSlot(MobSlot):
     @property
     def origin(self):
         return self['Origin'].value
+
     @origin.setter
     def origin(self, value):
         self['Origin'].value = value
@@ -137,6 +142,7 @@ class TimelineMobSlot(MobSlot):
             return length
         else:
             return segment.length
+
 
 @register_class
 class StaticMobSlot(MobSlot):

--- a/aaf2/properties.py
+++ b/aaf2/properties.py
@@ -9,6 +9,7 @@ from __future__ import (
 from io import BytesIO
 import weakref
 import struct
+
 from .utils import (
     read_u8,
     read_u16le,
@@ -398,6 +399,7 @@ class StrongRefProperty(Property):
 
 class StrongRefVectorProperty(Property):
     __slots__ = ('references', 'next_free_key', 'last_free_key','objects', '_index_name')
+
     def __init__(self, parent, pid, format, version=PROPERTY_VERSION):
         super(StrongRefVectorProperty, self).__init__(parent, pid, format, version)
         self.references = []
@@ -496,7 +498,6 @@ class StrongRefVectorProperty(Property):
         return "%s{%x}" % (self.index_name, self.references[index])
 
     def get(self, index, default=None):
-
         if index >= len(self.references):
             return default
 
@@ -854,7 +855,7 @@ class StrongRefSetProperty(Property):
         # check values are the correct type
         for item in values:
             if not classdef.isinstance(item.classdef):
-                raise TypeError("Invalid Value")
+                raise TypeError(f'Invalid Value, expected {classdef}, got {item.classdef}')
             if item.dir:
                 raise AAFAttachError("object already attached")
 
@@ -968,7 +969,7 @@ class StrongRefSetProperty(Property):
 
 def resolve_weakref(p, ref):
     ref_class_id = p.ref_classdef.auid
-    if ref_class_id   == CLASSDEF_AUID:
+    if ref_class_id == CLASSDEF_AUID:
         return p.parent.root.metadict.lookup_classdef(ref)
     elif ref_class_id == TYPEDEF_AUID:
         return p.parent.root.metadict.lookup_typedef(ref)

--- a/aaf2/properties.py
+++ b/aaf2/properties.py
@@ -855,7 +855,7 @@ class StrongRefSetProperty(Property):
         # check values are the correct type
         for item in values:
             if not classdef.isinstance(item.classdef):
-                raise TypeError(f'Invalid Value, expected {classdef}, got {item.classdef}')
+                raise TypeError("Invalid Value, expected {}, got {}".format(classdef, item.classdef))
             if item.dir:
                 raise AAFAttachError("object already attached")
 

--- a/aaf2/types.py
+++ b/aaf2/types.py
@@ -392,6 +392,7 @@ class TypeDefVarArray(TypeDef):
     def element_typedef(self):
         if PID_VAR_TYPE in self.property_entries:
             return self.root.metadict.lookup_typedef(self.property_entries[PID_VAR_TYPE].ref)
+
     @property
     def ref_classdef(self):
         typedef = self.element_typedef


### PR DESCRIPTION
This PR makes it possible to add offlined media to an AAF by supplying `offline=True` to `import_dnxhd_essence`, in which case the data won't be written to the essence. The offlined media can then be relinked using e.g. the tape name in Avid Media Composer, allowing you to create sequences that refer to essences that have already been sent to Media Composer previously.

The PR also includes some additional setters and getters for convenience, along with some aesthetic formatting changes.