### PR TITLE
Always close AAFFile's resources when exiting context manager

### DIFF
--- a/src/aaf2/file.py
+++ b/src/aaf2/file.py
@@ -150,6 +150,23 @@ class AAFFile(object):
     It is recommended to create this object with the `aaf.open` alias.
     It is also highly recommended to use the with statement.
 
+    .. warning::
+       If an exception is raised inside the with block and the file was opened
+       as writable, the final file should be considered bad or corrupted.
+
+       Take this snippet as an example:
+
+       .. code-block:: python
+
+           try:
+               with aaf.open('/path/to/aaf_file.aaf', 'r+') as f:
+                   raise ValueError('asd')
+           except:
+               pass
+
+       in this case, even if the exception is properly handled, the content
+       of ``/path/to/aaf_file.aaf`` shouldn't be trusted anymore.
+
     For example. Opening existing AAF file readonly::
 
         with aaf.open('/path/to/aaf_file.aaf', 'r') as f:
@@ -328,6 +345,12 @@ class AAFFile(object):
     def __exit__(self, exc_type, exc_value, traceback):
         if (exc_type is None and exc_value is None and traceback is None):
             self.close()
+        else:
+            self.is_open = False
+            try:
+                self.cfb.close()
+            finally:
+                self.f.close()
 
     def __enter__(self):
         return self

--- a/tests/test_aaf.py
+++ b/tests/test_aaf.py
@@ -36,6 +36,143 @@ class AAFTests(unittest.TestCase):
         with aaf2.open(new_file, 'r') as f:
             common.walk_aaf(f.root)
 
+    def test_exit_with_exception_no_save(self):
+        new_file = os.path.join(common.sandbox(), 'save_with_exception_no_save.aaf')
+        test_file = common.test_file_01()
+        shutil.copy(test_file, new_file)
+
+        with self.assertRaises(ValueError):
+            with aaf2.open(new_file, 'r+') as f:
+                # mobs = f.content.mobs
+                mob = f.create.MasterMob("TestExitMob")
+                f.content.mobs.append(mob)
+
+                raise ValueError('asd')
+
+        self.assertTrue(f.f.closed)
+        self.assertFalse(f.is_open)
+        self.assertFalse(f.cfb.is_open)
+
+        with open(test_file, 'rb') as testFile:
+            with open(new_file, 'rb') as newFile:
+                self.assertNotEqual(testFile.read(), newFile.read())
+
+        with aaf2.open(new_file, 'r') as f:
+            # Make sure that the file can still be opened with aaf2.open
+            # and that the save method wasn't run.
+            self.assertIsNone(f.content.mobs.get('TestExitMob'))
+
+    def test_exit_with_exception_with_save(self):
+
+        new_file = os.path.join(common.sandbox(), 'save_with_exception_with_save.aaf')
+        test_file = common.test_file_01()
+        shutil.copy(test_file, new_file)
+
+        with self.assertRaises(ValueError):
+            with aaf2.open(new_file, 'r+') as f:
+                # mobs = f.content.mobs
+                mob = f.create.MasterMob("TestExitMob")
+                f.content.mobs.append(mob)
+
+                f.save()
+
+                raise ValueError('asd')
+
+        self.assertTrue(f.f.closed)
+        self.assertFalse(f.is_open)
+        self.assertFalse(f.cfb.is_open)
+
+        with open(test_file, 'rb') as testFile:
+            with open(new_file, 'rb') as newFile:
+                self.assertNotEqual(testFile.read(), newFile.read())
+
+        with aaf2.open(new_file, 'r') as f:
+            # Make sure that the file can still be opened with aaf2.open
+            # and that the save method wasn't run.
+            self.assertIsNotNone(f.content.mobs.get('TestExitMob'))
+
+    def test_exit_with_internal_exception(self):
+        """This scenario is a bad situation... explosion
+        Exercise the scenario where no exception occurs inside with with block, but
+        an exception occurs during the exit phase of the context manager.
+        """
+
+        new_file = os.path.join(common.sandbox(), 'save_with_exception_with_save.aaf')
+        test_file = common.test_file_01()
+        shutil.copy(test_file, new_file)
+
+        with self.assertRaises(RuntimeError):
+            with aaf2.open(new_file, 'r+') as f:
+                def mock(*args, **kwargs):
+                    raise RuntimeError('asd')
+
+                # This will result in a corrupted file
+                f.cfb.close = mock
+
+                # mobs = f.content.mobs
+                mob = f.create.MasterMob("TestExitMob")
+                f.content.mobs.append(mob)
+
+                f.save()
+
+        self.assertFalse(f.f.closed)
+        self.assertTrue(f.is_open)
+        self.assertTrue(f.cfb.is_open)
+
+        with open(test_file, 'rb') as testFile:
+            with open(new_file, 'rb') as newFile:
+                self.assertNotEqual(testFile.read(), newFile.read())
+
+        with self.assertRaises(IndexError):
+            # new_file is now corrupted.
+            with aaf2.open(new_file, 'r') as f:
+                pass
+
+    def test_exit_with_internal_and_external_exception(self):
+        # Exception occurs in with block and also in the except clause
+        # while closing file descriptors.
+
+        new_file = os.path.join(common.sandbox(), 'save_with_exception_with_save.aaf')
+        test_file = common.test_file_01()
+        shutil.copy(test_file, new_file)
+
+        # Notice how the exception propagated is not a ValueError.
+        with self.assertRaises(RuntimeError):
+            with aaf2.open(new_file, 'r+') as f:
+                def mock(*args, **kwargs):
+                    raise RuntimeError('asd')
+
+                # This will result in a corrupted file
+                f.cfb.close = mock
+
+                # mobs = f.content.mobs
+                mob = f.create.MasterMob("TestExitMob")
+                f.content.mobs.append(mob)
+
+                f.save()
+
+                raise ValueError('asd')
+
+        # And also the file is still closed even if the cfb failed to be closed.
+        self.assertTrue(f.f.closed)
+        self.assertFalse(f.is_open)
+        self.assertTrue(f.cfb.is_open)
+
+        with open(test_file, 'rb') as testFile:
+            with open(new_file, 'rb') as newFile:
+                self.assertNotEqual(testFile.read(), newFile.read())
+
+        with self.assertRaises(IndexError):
+            # new_file is now corrupted.
+            with aaf2.open(new_file, 'r') as f:
+                pass
+
+    def test_save_after_close(self):
+        aaf_file = aaf2.open()
+        aaf_file.close()
+        with self.assertRaises(IOError):
+            aaf_file.save()
+
 
 if __name__ == "__main__":
     import logging

--- a/tests/test_aaf.py
+++ b/tests/test_aaf.py
@@ -37,7 +37,7 @@ class AAFTests(unittest.TestCase):
             common.walk_aaf(f.root)
 
     def test_exit_with_exception_no_save(self):
-        new_file = os.path.join(common.sandbox(), 'save_with_exception_no_save.aaf')
+        new_file = os.path.join(common.sandbox(), 'test_exit_with_exception_no_save.aaf')
         test_file = common.test_file_01()
         shutil.copy(test_file, new_file)
 
@@ -64,7 +64,7 @@ class AAFTests(unittest.TestCase):
 
     def test_exit_with_exception_with_save(self):
 
-        new_file = os.path.join(common.sandbox(), 'save_with_exception_with_save.aaf')
+        new_file = os.path.join(common.sandbox(), 'test_exit_with_exception_with_save.aaf')
         test_file = common.test_file_01()
         shutil.copy(test_file, new_file)
 
@@ -97,7 +97,7 @@ class AAFTests(unittest.TestCase):
         an exception occurs during the exit phase of the context manager.
         """
 
-        new_file = os.path.join(common.sandbox(), 'save_with_exception_with_save.aaf')
+        new_file = os.path.join(common.sandbox(), 'test_exit_with_internal_exception.aaf')
         test_file = common.test_file_01()
         shutil.copy(test_file, new_file)
 
@@ -132,7 +132,7 @@ class AAFTests(unittest.TestCase):
         # Exception occurs in with block and also in the except clause
         # while closing file descriptors.
 
-        new_file = os.path.join(common.sandbox(), 'save_with_exception_with_save.aaf')
+        new_file = os.path.join(common.sandbox(), 'test_exit_with_internal_and_external_exception.aaf')
         test_file = common.test_file_01()
         shutil.copy(test_file, new_file)
 
@@ -166,6 +166,20 @@ class AAFTests(unittest.TestCase):
             # new_file is now corrupted.
             with aaf2.open(new_file, 'r') as f:
                 pass
+
+    def test_raise_on_close_in_except(self):
+        # Test that AAFFile.f.close exceptions are propagated to
+        # the user's code.
+        with self.assertRaises(RuntimeError):
+            with aaf2.open() as fd:
+                def mock(*args, **kwargs):
+                    raise RuntimeError('asd')
+
+                originalClose = fd.f.close
+                fd.f.close = mock
+                raise ValueError('asd')
+
+        originalClose()
 
     def test_save_after_close(self):
         aaf_file = aaf2.open()


### PR DESCRIPTION
Like discussed in private, this PR changes the behavior of the `AAFFile.__exit__` method so that it tries as best as it can to close file resources when exiting.

I added unit tests to cover the different scenarios that I could come up with.