### PR TITLE
Added MXFCompositionPackage

### DIFF
--- a/src/aaf2/mxf.py
+++ b/src/aaf2/mxf.py
@@ -285,6 +285,12 @@ class MXFPackage(MXFObject):
         return mob
 
 @register_mxf_class
+class MXFCompositionPackage(MXFPackage):
+    class_id = AUID("060e2b34-0253-0101-0d01-010101013500")
+    def create_aaf_instance(self):
+        return self.root.aaf.create.CompositionMob()
+
+@register_mxf_class
 class MXFMaterialPackage(MXFPackage):
     class_id = AUID("060e2b34-0253-0101-0d01-010101013600")
     def create_aaf_instance(self):


### PR DESCRIPTION
I've been testing with an AAF file generated from an Avid system this evening, and the AAFDump tool provided by Avid was dumping TaggedValues for a CompositionMob that I was struggling to locate in pyaaf2.

Identified an AUID in the AAF that I think we're missing support for, so have attempted to add in.