### PR TITLE
fix a bug when getting a value for a parameter when there is only one…

### DIFF
--- a/src/aaf2/misc.py
+++ b/src/aaf2/misc.py
@@ -269,6 +269,8 @@ class VaryingValue(Parameter):
         if self.interpolationdef.auid == LinearInterp:
             t_len = float(p2.time) - float(p1.time)
             t_diff = t - float(p1.time)
+            if t_diff == 0:
+                return float(p1.value)
             t_mix = t_diff/t_len
 
             v0 = float(p1.value)


### PR DESCRIPTION
when there is only one key frame for a parameter in Avid Media Composer, exported aaf file have two ControlPoint with the exact value for that parameter.

When reading aaf file like this, value_at() method will fail when trying to get the value for the keyed frame.

This commit is a fix for a situation like this.
