### PR TITLE
 Fix incorrect function call from GetSourceMobs() to sourcemobs()

### DIFF
--- a/examples/qt_aafmodel.py
+++ b/examples/qt_aafmodel.py
@@ -222,7 +222,7 @@ class Window(QtWidgets.QTreeView):
             root = list(f.content.mastermobs())
 
         if options.sourcemobs:
-           root = list(f.content.GetSourceMobs())
+           root = list(f.content.sourcemobs())
 
         if options.dictionary:
             root = f.dictionary


### PR DESCRIPTION
 Fix incorrect function call from GetSourceMobs() to sourcemobs() in `examples/qt_aafmodel.py`