### PR TITLE
Feature/ffastrans improvements

### DIFF
--- a/src/aaf2/ama.py
+++ b/src/aaf2/ama.py
@@ -307,6 +307,17 @@ class StreamInfo:
 
         return (depth, h_samp, v_samp)
 
+    def get_hevc_compression(self):
+        if not self.is_picture:
+            return None
+
+        profile = self.metadata.get('profile', None)
+        key = 'CompressedPicture'
+        if profile == "Main":
+            key = 'HEVC_MainProfile_Unconstrained'
+       
+        return video.compression_ids_hevc[key]
+
     def get_avc_compression(self):
         if not self.is_picture:
             return None
@@ -355,6 +366,8 @@ class StreamInfo:
             return video.compression_ids['mjpeg']
         if codec_name == 'h264':
             return self.get_avc_compression()
+        if codec_name == 'hevc':
+            return self.get_hevc_compression()
 
         return video.compression_ids['CompressedPicture']
 

--- a/src/aaf2/cfb.py
+++ b/src/aaf2/cfb.py
@@ -7,6 +7,8 @@ from __future__ import (
 
 import logging
 
+_log = logging.getLogger(__name__)
+
 import sys
 import os
 import io
@@ -104,7 +106,7 @@ class Stream(object):
             raise ValueError('New position is before the start of the stream')
 
         if offset > self.dir.byte_size:
-            # logging.debug("overseek %d bytes, padding with zeros" % (offset - self.dir.byte_size))
+            # _log.debug("overseek %d bytes, padding with zeros" % (offset - self.dir.byte_size))
             self.pos = self.dir.byte_size
             bytes_left = offset - self.dir.byte_size
             min_seek_size = self.storage.sector_size * 4
@@ -211,7 +213,7 @@ class Stream(object):
         orig_pos = None
         # convert from minifat to fat
         if minifat and byte_size >= self.storage.min_stream_max_size:
-            # logging.debug("converting stream for minifat to fat")
+            # _log.debug("converting stream for minifat to fat")
             orig_pos = self.pos
             self.seek(0)
             realloc_data = self.read()
@@ -226,7 +228,7 @@ class Stream(object):
         sector_count = (byte_size + sector_size - 1) // sector_size
 
         current_sects= len(self.fat_chain)
-        # logging.debug("%d bytes requires %d sectors at %d has %d" % (byte_size, sector_count, self.sector_size(), current_sects))
+        # _log.debug("%d bytes requires %d sectors at %d has %d" % (byte_size, sector_count, self.sector_size(), current_sects))
 
         while len(self.fat_chain) < sector_count:
             last_sector_id = self.fat_chain[-1] if self.fat_chain else None
@@ -1116,10 +1118,10 @@ class CompoundFileBinary(object):
             # create dir_fat_chain and read root dir entry
             self.dir_fat_chain = self.get_fat_chain(self.dir_sector_start)
             if len(self.dir_fat_chain) != self.dir_sector_count:
-                logging.info("read dir_sector_count missmatch, using fat chain length")
+                _log.info("read dir_sector_count missmatch, using fat chain length")
                 self.dir_sector_count = len(self.dir_fat_chain)
 
-            logging.debug("read %d dir sectors" % len(self.dir_fat_chain))
+            _log.debug("read %d dir sectors" % len(self.dir_fat_chain))
             self.root = self.read_dir_entry(0)
             self.dir_cache[0] = self.root
 
@@ -1129,14 +1131,14 @@ class CompoundFileBinary(object):
 
             if self.root.sector_id is not None and mini_stream_byte_size != self.root.byte_size:
                 message = "mini stream size missmatch: %d != %d, using size from minifat"
-                logging.warning(message % (self.root.byte_size, mini_stream_byte_size))
+                _log.warning(message % (self.root.byte_size, mini_stream_byte_size))
         else:
             self.setup_empty(sector_size)
             self.write_header()
 
-            logging.debug("pos: %d" % self.f.tell())
+            _log.debug("pos: %d" % self.f.tell())
 
-            logging.debug("writing root dir sector")
+            _log.debug("writing root dir sector")
             self.root.write()
             self.f.write(bytearray(self.sector_size - 128))
             self.write_fat()
@@ -1239,7 +1241,7 @@ class CompoundFileBinary(object):
         # raise NotImplementedError("mode: %s supported not implemented" % self.f.mode)
 
     def write_header(self):
-        logging.debug("writiing header")
+        _log.debug("writiing header")
         f = self.f
         f.seek(0)
         f.write(b'\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1') # Magic
@@ -1276,19 +1278,19 @@ class CompoundFileBinary(object):
         f.seek(0)
 
         self.magic = f.read(8)
-        logging.debug("magic: %s" % str([self.magic]))
+        _log.debug("magic: %s" % str([self.magic]))
 
         if self.magic != b'\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1':
             raise CompoundFileBinaryError("invalid file magic signature: {}".format([self.magic]))
 
         self.class_id = auid.AUID(bytes_le=f.read(16))
-        logging.debug("clsid: %s" % str(self.class_id))
+        _log.debug("clsid: %s" % str(self.class_id))
 
         self.minor_version = read_u16le(f)
-        logging.debug("minor_version: %d" % self.minor_version)
+        _log.debug("minor_version: %d" % self.minor_version)
 
         self.major_version = read_u16le(f)
-        logging.debug("major_version: %d" % self.major_version)
+        _log.debug("major_version: %d" % self.major_version)
 
         byte_order = read_u16le(f)
         if byte_order == 0xFFFE:
@@ -1296,15 +1298,15 @@ class CompoundFileBinary(object):
         else:
             raise NotImplementedError("endian format:0x%X not supported" % byte_order)
 
-        logging.debug("byte_order: %s" % self.byte_order)
+        _log.debug("byte_order: %s" % self.byte_order)
 
         size = read_u16le(f)
         self.sector_size = pow(2, size)
-        logging.debug("sector_size: %d -> %d" % (size, self.sector_size))
+        _log.debug("sector_size: %d -> %d" % (size, self.sector_size))
 
         size = read_u16le(f)
         self.mini_stream_sector_size = pow(2, size)
-        logging.debug("mini_stream_sector_size: %d -> %d" % (size, self.mini_stream_sector_size))
+        _log.debug("mini_stream_sector_size: %d -> %d" % (size, self.mini_stream_sector_size))
 
         if not self.sector_size in (4096, 512):
             raise NotImplementedError("unsupported sector size: %d" % self.sector_size)
@@ -1314,35 +1316,35 @@ class CompoundFileBinary(object):
         f.read(6) # skip reserved
 
         self.dir_sector_count = read_u32le(f)
-        logging.debug("dir_sector_count: %d" % self.dir_sector_count)
+        _log.debug("dir_sector_count: %d" % self.dir_sector_count)
 
         self.fat_sector_count = read_u32le(f)
-        logging.debug("fat_sector_count: %d" % self.fat_sector_count)
+        _log.debug("fat_sector_count: %d" % self.fat_sector_count)
 
         self.dir_sector_start = read_u32le(f)
-        logging.debug("dir_sector_start: %d" % self.dir_sector_start)
+        _log.debug("dir_sector_start: %d" % self.dir_sector_start)
 
         self.transaction_signature = read_u32le(f)
-        logging.debug("transaction_signature: %d" % self.transaction_signature)
+        _log.debug("transaction_signature: %d" % self.transaction_signature)
 
         self.min_stream_max_size = read_u32le(f)
-        logging.debug("min_stream_max_size: %d" % self.min_stream_max_size)
+        _log.debug("min_stream_max_size: %d" % self.min_stream_max_size)
 
         self.minifat_sector_start = read_u32le(f)
-        logging.debug("minifat_sector_start: %d" % self.minifat_sector_start)
+        _log.debug("minifat_sector_start: %d" % self.minifat_sector_start)
 
         self.minifat_sector_count = read_u32le(f)
-        logging.debug("minifat_sector_count: %d" % self.minifat_sector_count)
+        _log.debug("minifat_sector_count: %d" % self.minifat_sector_count)
 
         self.difat_sector_start = read_u32le(f)
-        logging.debug("difat_sector_start: %d" % self.difat_sector_start)
+        _log.debug("difat_sector_start: %d" % self.difat_sector_start)
 
         self.difat_sector_count = read_u32le(f)
-        logging.debug("difat_sector_count: %d" % self.difat_sector_count)
+        _log.debug("difat_sector_count: %d" % self.difat_sector_count)
 
         self.difat = [[]]
 
-        logging.debug("reading header difat at %d" % f.tell())
+        _log.debug("reading header difat at %d" % f.tell())
         for i in range(109):
             item = read_u32le(f)
             self.difat[0].append(item)
@@ -1353,7 +1355,7 @@ class CompoundFileBinary(object):
 
         # reading difat sectors
         while sectors_left:
-            logging.debug("reading difat sid: %d", sid)
+            _log.debug("reading difat sid: %d", sid)
             sector_type = fat_sector_types.get(sid, sid)
             if not isinstance(sector_type, int):
                 break
@@ -1367,7 +1369,7 @@ class CompoundFileBinary(object):
             self.difat.append(difat)
 
             sid = difat[-1]
-            logging.debug("next difat: %d" % sid)
+            _log.debug("next difat: %d" % sid)
             sectors_left -= 1
 
     def iter_difat(self):
@@ -1386,7 +1388,7 @@ class CompoundFileBinary(object):
         # write header entries
         f.seek(76)
 
-        logging.debug("writing header difat")
+        _log.debug("writing header difat")
         for i in range(109):
             write_u32le(f, self.difat[0][i])
 
@@ -1405,7 +1407,7 @@ class CompoundFileBinary(object):
                 raise IOError("bad difat sector type")
 
             pos = (sid + 1) * self.sector_size
-            logging.debug("writing difat to sid: %d at: %d" % (sid,pos))
+            _log.debug("writing difat to sid: %d at: %d" % (sid,pos))
             f.seek(pos)
             for i in range(self.sector_size // 4):
                 write_u32le(f, table[i])
@@ -1428,7 +1430,7 @@ class CompoundFileBinary(object):
         #  len(fat_sectors),self.fat_sector_count
         # assert len(fat_sectors) == self.fat_sector_count
         if len(fat_sectors) != self.fat_sector_count:
-            logging.warning("fat sector count missmatch difat: %d header: %d" % (len(fat_sectors), self.fat_sector_count))
+            _log.warning("fat sector count missmatch difat: %d header: %d" % (len(fat_sectors), self.fat_sector_count))
             self.fat_sector_count = len(fat_sectors)
 
         for sid in fat_sectors:
@@ -1444,14 +1446,14 @@ class CompoundFileBinary(object):
             if v == FREESECT:
                 self.fat_freelist.append(i)
 
-        logging.debug("read %d fat sectors ", sector_count)
+        _log.debug("read %d fat sectors ", sector_count)
 
         if self.sector_size == 4096 and len(self.fat) > RANGELOCKSECT:
             if self.fat[RANGELOCKSECT] != ENDOFCHAIN:
-                logging.warning("range lock sector has data")
+                _log.warning("range lock sector has data")
 
     def write_fat(self):
-        logging.debug("writing fat")
+        _log.debug("writing fat")
         f = self.f
         sector_count = 0
 
@@ -1472,7 +1474,7 @@ class CompoundFileBinary(object):
         fat_table_struct = Struct(str('<%dI' % element_count))
         for i, sid in enumerate(fat_sectors):
 
-            # logging.debug("writing fat to sid: %d" % sid)
+            # _log.debug("writing fat to sid: %d" % sid)
             f.seek((sid + 1) *  self.sector_size)
             start = i * element_count
             end = start + element_count
@@ -1501,7 +1503,7 @@ class CompoundFileBinary(object):
 
         mini_stream_byte_size = ((last_used_sector+1) * self.mini_stream_sector_size)
 
-        logging.debug("read %d mini fat sectors", sector_count)
+        _log.debug("read %d mini fat sectors", sector_count)
         return mini_stream_byte_size
 
     def write_minifat(self):
@@ -1575,7 +1577,7 @@ class CompoundFileBinary(object):
 
         # if we got here need to add additional fat
         sid = self.next_free_sect()
-        # logging.warning("growing minifat to sid %d" % sid)
+        # _log.warning("growing minifat to sid %d" % sid)
 
         idx_start = len(self.minifat)
         idx_end = idx_start + self.sector_size // 4
@@ -1605,12 +1607,12 @@ class CompoundFileBinary(object):
             # Handle Range Lock Sector
             if i == RANGELOCKSECT and self.sector_size == 4096:
                 self.fat[i] = ENDOFCHAIN
-                logging.warning("range lock sector in fat freelist, marking ENDOFCHAIN")
+                _log.warning("range lock sector in fat freelist, marking ENDOFCHAIN")
                 return self.next_free_sect()
             return i
 
         # if we got here need to add additional fat
-        # logging.debug("fat full, growing")
+        # _log.debug("fat full, growing")
 
         difat_table = None
         difat_index = None
@@ -1624,7 +1626,7 @@ class CompoundFileBinary(object):
         new_difat_sect = None
         if difat_index is None:
             new_difat_sect = len(self.fat) + 1
-            logging.debug("adding new difat to sid: %d" % new_difat_sect)
+            _log.debug("adding new difat to sid: %d" % new_difat_sect)
             if self.difat_sector_count == 0:
                 self.difat_sector_start = new_difat_sect
                 self.difat_sector_count = 1
@@ -1647,7 +1649,7 @@ class CompoundFileBinary(object):
                     break
 
         new_fat_sect = len(self.fat)
-        # logging.debug("adding new fat to sid: %d" % new_fat_sect)
+        # _log.debug("adding new fat to sid: %d" % new_fat_sect)
 
         self.difat[difat_table][difat_index] = new_fat_sect
 
@@ -1664,7 +1666,7 @@ class CompoundFileBinary(object):
         # that covers file offsets 0x7FFFFF00-0x7FFFFFFF in the file
         if RANGELOCKSECT < idx_end and RANGELOCKSECT > idx_start and self.sector_size == 4096:
             non_free_sids.add(RANGELOCKSECT)
-            logging.debug("adding range lock")
+            _log.debug("adding range lock")
             self.fat[RANGELOCKSECT] = ENDOFCHAIN
 
         freelist = [i for i in range(idx_start, idx_end) if i not in non_free_sids]
@@ -1786,7 +1788,7 @@ class CompoundFileBinary(object):
 
     def mini_stream_grow(self):
         sid = self.next_free_sect()
-        # logging.debug("adding to mini stream fat sid: %d" %  sid)
+        # _log.debug("adding to mini stream fat sid: %d" %  sid)
         if not self.mini_stream_chain:
             self.mini_stream_chain = [sid]
             self.root.sector_id = sid
@@ -1800,11 +1802,11 @@ class CompoundFileBinary(object):
 
         if minifat:
             sect = self.next_free_minifat_sect()
-            # logging.debug("creating new mini sector: %d" % sect)
+            # _log.debug("creating new mini sector: %d" % sect)
             fat = self.minifat
         else:
             sect = self.next_free_sect()
-            # logging.debug("creating new sector: %d" % sect)
+            # _log.debug("creating new sector: %d" % sect)
             fat = self.fat
 
         if start_sid is None:
@@ -1847,7 +1849,7 @@ class CompoundFileBinary(object):
             raise ValueError("can not add entry to non storage type")
 
         dir_id = self.next_free_dir_id()
-        logging.debug("next dir id %d" % dir_id)
+        _log.debug("next dir id %d" % dir_id)
 
         entry = DirEntry(self, dir_id)
         entry.name = basename
@@ -2153,7 +2155,7 @@ class CompoundFileBinary(object):
                 raise ValueError("can only open stream type DirEntry's")
 
             if mode == 'w':
-                logging.debug("stream: %s exists, overwriting" % path)
+                _log.debug("stream: %s exists, overwriting" % path)
                 self.free_fat_chain(entry.sector_id, entry.byte_size < self.min_stream_max_size)
                 entry.sector_id = None
                 entry.byte_size = 0

--- a/src/aaf2/content.py
+++ b/src/aaf2/content.py
@@ -71,7 +71,8 @@ class ContentStorage(core.AAFObject):
     def link_external_mxf(self, path):
         m = mxf.MXFFile(path)
         if m.operation_pattern != "OPAtom":
-            raise Exception("can only link OPAtom mxf files")
+            # raise Exception("can only link OPAtom mxf files")
+            pass
         return m.link(self.root)
 
     def link_external_wav(self, metadata):

--- a/src/aaf2/mxf.py
+++ b/src/aaf2/mxf.py
@@ -771,6 +771,19 @@ class MXFImportDescriptor(MXFDescriptor):
     def link(self):
         d = self.create_aaf_instance()
         n = self.root.aaf.create.NetworkLocator()
+
+        # Prefer an existing Locator already embedded in the MXF (e.g. the Avid
+        # physical-package Network Locator set by bmxtranswrap's --import
+        if ("Locator" in self.data
+            and len(self.data["Locator"]) == 1
+            and self.data["Locator"][0] in self.root.objects):
+            _loc = self.root.objects[self.data["Locator"][0]]
+            if ("URLString" in _loc.data):
+                n['URLString'].value = _loc.data["URLString"]
+                d['Locator'].append(n)
+                return d
+
+        # Fallback: no usable embedded locator -> use the MXF's own path.
         n['URLString'].value = ama_path(self.root.path)
         d['Locator'].append(n)
 

--- a/src/aaf2/mxf.py
+++ b/src/aaf2/mxf.py
@@ -588,6 +588,8 @@ class MXFMultipleDescriptor(MXFDescriptor):
         for item in self.iter_strong_refs("FileDescriptors"):
             # if isinstance(item, MXFAES3AudioDescriptor):
             #     continue
+            if item is None:
+                continue
             d['FileDescriptors'].append(item.link())
         d['Length'].value = self.data.get('Length', 0)
 
@@ -595,7 +597,8 @@ class MXFMultipleDescriptor(MXFDescriptor):
         n['URLString'].value = ama_path(self.root.path)
         d['Locator'].append(n)
 
-        d['SampleRate'].value = self.data['SampleRate']
+        if 'SampleRate' in self.data:
+            d['SampleRate'].value = self.data['SampleRate']
 
         if self.root.ama:
             n = self.root.aaf.create.NetworkLocator()
@@ -629,7 +632,10 @@ class MXFCDCIDescriptor(MXFDescriptor):
                 d[key].value = self.data[key]
 
         for item in self.iter_strong_refs("Locator"):
-            d['Locator'].append(item.link())
+            if item is not None:
+                d['Locator'].append(item.link())
+        
+        if not len(d['Locator']):
             n = self.root.aaf.create.NetworkLocator()
             n['URLString'].value = ama_path(self.root.path)
             d['Locator'].append(n)

--- a/src/aaf2/mxf.py
+++ b/src/aaf2/mxf.py
@@ -882,6 +882,69 @@ def iter_tags(f, length):
 def auid_to_str_list(v, sep=',', prefix=""):
     return sep.join('%s%02x' % (prefix, i)  for i in bytearray(v.bytes_be))
 
+
+# === BEGIN footer-first MXF parsing (added 2026-05-02) =======================
+# Speeds up parsing of MXF files whose header is not Closed Complete by jumping
+# straight to the footer's repeated metadata via the Random Index Pack at EOF.
+#
+# Disable at runtime with env var PYAAF2_MXF_FOOTER_FIRST=0 to fall back to
+# header-walk only (original behavior).
+#
+
+def _strip_version(auid):
+    """Return the UL's 16 bytes with byte 7 (registry version) zeroed out,
+    so equality is tolerant to registry-version bumps in muxer output. None
+    in → None out, so the helper composes with read_auid_be at EOF."""
+    if auid is None:
+        return None
+    b = bytearray(auid.bytes_be)
+    b[7] = 0
+    return bytes(b)
+
+# Partition Pack ULs per SMPTE 377M (byte 13 = kind, byte 14 = status).
+# Stored as byte-7-masked bytes so lookups via _strip_version() are version-tolerant.
+_HEADER_PARTITION_PACK_KEYS = frozenset(_strip_version(AUID(s)) for s in (
+    "060e2b34-0205-0101-0d01-020101020100",  # Open Incomplete
+    "060e2b34-0205-0101-0d01-020101020200",  # Closed Incomplete
+    "060e2b34-0205-0101-0d01-020101020300",  # Open Complete
+    "060e2b34-0205-0101-0d01-020101020400",  # Closed Complete
+))
+_FOOTER_PARTITION_PACK_KEYS = frozenset(_strip_version(AUID(s)) for s in (
+    "060e2b34-0205-0101-0d01-020101040200",  # Closed Incomplete
+    "060e2b34-0205-0101-0d01-020101040400",  # Closed Complete
+))
+_PRIMER_KEY = _strip_version(AUID("060e2b34-0205-0101-0d01-020101050100"))
+_RIP_KEY    = _strip_version(AUID("060e2b34-0205-0101-0d01-020101110100"))
+
+
+def _read_rip_footer_offset(f, file_size):
+    """Return the absolute byte offset of the footer partition by reading the
+    Random Index Pack at end-of-file, or None if the file has no usable RIP
+    (partial files, growing files, or non-conforming muxers).
+    """
+    if file_size < 20:
+        return None
+    f.seek(file_size - 4)
+    rip_total = read_u32be(f)
+    if rip_total < 20 or rip_total > file_size:
+        return None
+    f.seek(file_size - rip_total)
+    if _strip_version(read_auid_be(f)) != _RIP_KEY:
+        return None
+    payload_len = ber_length(f)
+    # RIP payload is N entries of (BodySID:u32 + ByteOffset:u64) = 12 bytes each.
+    # The last entry points to the footer partition.
+    n = payload_len // 12
+    if n == 0:
+        return None
+    last_offset = None
+    for _ in range(n):
+        f.read(4)  # BodySID — discarded
+        last_offset = read_u64be(f)
+    return last_offset
+# === END footer-first MXF parsing ============================================
+
+
 class MXFFile(object):
 
     def __init__(self, path):
@@ -894,29 +957,101 @@ class MXFFile(object):
         self.ama = False
         self.aaf = None
         with io.open(path, 'rb') as f:
+            # Try the footer-first fast path (RIP → footer's repeated metadata).
+            # Set PYAAF2_MXF_FOOTER_FIRST=0 to disable and use header-walk only.
+            if os.environ.get('PYAAF2_MXF_FOOTER_FIRST', '1') != '0':
+                if self._try_parse_from_footer(f):
+                    return
+            self._parse_from_header_walk(f)
 
-            for key, length in iter_kl(f):
+    def _parse_from_header_walk(self, f):
+        # Original parsing path: walk KLVs from the start of the file, picking
+        # up the primer + header partition pack + metadata sets, stopping once
+        # we've passed the header partition's announced size.
+        #
+        # Behavior change vs. pre-2026-05-02: matches all four header partition
+        # pack variants (Open/Closed × Incomplete/Complete) instead of only
+        # Closed Complete, so the early-exit guard fires on those files too
+        # rather than walking the entire file.
+        f.seek(0)
+        for key, length in iter_kl(f):
+            if not self.header_partition_size is None and f.tell() > self.header_partition_size:
+                break
+            mkey = _strip_version(key)
+            if mkey == _PRIMER_KEY:
+                self.local_tags = self.read_primer(f, length)
+            elif mkey in _HEADER_PARTITION_PACK_KEYS:
+                self.read_header(f, length)
+            else:
+                obj = self.read_object(f, key, length)
+                if obj:
+                    obj.root = self
+                    self.objects[obj.instance_id] = obj
+                if isinstance(obj, MXFPreface):
+                    self.preface = obj
 
-                # only read until the first body partition
-                if not self.header_partition_size is None and f.tell() > self.header_partition_size:
-                    break
+    def _try_parse_from_footer(self, f):
+        # Try to populate state from the footer partition's repeated metadata,
+        # located via the Random Index Pack at EOF. Returns True on success.
+        # On any failure (no RIP, footer without metadata repetition, parse
+        # error) returns False with state reset so the header-walk fallback
+        # starts clean.
+        try:
+            success = self._parse_footer_inner(f)
+        except Exception:
+            success = False
+        if success:
+            return True
+        self.preface = None
+        self.objects = {}
+        self.local_tags = {}
+        self.header_operation_pattern = None
+        self.header_partition_size = None
+        return False
 
-                if key == AUID("060e2b34-0205-0101-0d01-020101050100"):
-                    self.local_tags = self.read_primer(f, length)
-                elif key == AUID("060e2b34-0205-0101-0d01-020101020400"):
-                    self.read_header(f, length)
-                else:
-                    # print('{')
-                    # print(key,  auid_to_str_list(key, sep='.'))
-                    obj = self.read_object(f, key, length)
-                    if obj:
-                        # print(obj.__class__.__name__, obj.instance_id)
-                        obj.root = self
-                        self.objects[obj.instance_id] = obj
+    def _parse_footer_inner(self, f):
+        f.seek(0, io.SEEK_END)
+        file_size = f.tell()
+        footer_offset = _read_rip_footer_offset(f, file_size)
+        if footer_offset is None or footer_offset >= file_size:
+            return False
 
-                    if isinstance(obj, MXFPreface):
-                        self.preface = obj
-                    # print('}')
+        f.seek(footer_offset)
+        key = read_auid_be(f)
+        if _strip_version(key) not in _FOOTER_PARTITION_PACK_KEYS:
+            return False
+        length = ber_length(f)
+        pack_value_start = f.tell()
+        # Footer partition pack has the same layout as the header pack, so
+        # read_header populates header_partition_size / header_operation_pattern
+        # from footer values — which on a finalized file equal the header's.
+        self.read_header(f, length)
+        # Skip any unread bytes of the partition pack (e.g. EssenceContainers list).
+        f.seek(pack_value_start + length)
+
+        metadata_end = footer_offset + self.header_partition_size
+        if metadata_end <= f.tell():
+            # Footer pack reports header_byte_count == 0, i.e. no metadata
+            # repetition here. Fall back to header walk.
+            return False
+
+        for k, klen in iter_kl(f):
+            if f.tell() > metadata_end:
+                break
+            mk = _strip_version(k)
+            if mk == _PRIMER_KEY:
+                self.local_tags = self.read_primer(f, klen)
+            elif mk in _HEADER_PARTITION_PACK_KEYS or mk in _FOOTER_PARTITION_PACK_KEYS:
+                # Hit the next partition (or RIP) — done.
+                break
+            else:
+                obj = self.read_object(f, k, klen)
+                if obj:
+                    obj.root = self
+                    self.objects[obj.instance_id] = obj
+                if isinstance(obj, MXFPreface):
+                    self.preface = obj
+        return self.preface is not None
 
     def resolve(self, ref):
         if isinstance(ref, MXFRef):

--- a/src/aaf2/mxf.py
+++ b/src/aaf2/mxf.py
@@ -7,6 +7,8 @@ from __future__ import (
 import sys
 import struct
 import datetime
+import os
+import urllib.parse
 
 from io import BytesIO
 import io
@@ -141,9 +143,20 @@ def decode_mob_id(data):
     m = MobID(str(uid1) + str(uid2))
     return m
 
-def ama_path(path):
-    prefix ="file://"
-    return prefix + path
+def ama_path(path: str) -> str:
+    if path.startswith('\\\\'):
+        # UNC path, avid want this with two slashes at the start
+        
+        encoded_path = urllib.parse.quote(path.replace("\\", "/"), safe='/')
+        return f"file:{encoded_path}"
+    elif ':' in path:
+        # Local drive path, for avid we must append three slashes, otherwise it does not detect Source Path and Name correctly in the bin
+        encoded_path = urllib.parse.quote(path.replace("\\", "/"), safe='/')
+        return f"file:///{encoded_path}"
+    else:
+        # fallback for relative paths or non-Windows (untested)
+        encoded_path = urllib.parse.quote(path.replace("\\", "/"), safe='/')
+        return f"file://{encoded_path}"
 
 class MXFObject(object):
     def __init__(self):

--- a/src/aaf2/mxf.py
+++ b/src/aaf2/mxf.py
@@ -569,6 +569,12 @@ class MXFDescriptor(MXFObject):
                 self.data['Locator'] = decode_strong_ref_array(f)
             elif tag == 0x3401:
                 self.data['PixelLayout'] = decode_pixel_layout(f)
+            elif tag == 0x3210:
+                self.data['TransferCharacteristic'] = reverse_auid(decode_auid(data)) #0x3210
+            elif tag == 0x3219:
+                self.data['ColorPrimaries'] = reverse_auid(decode_auid(data)) #0x3219
+            elif tag == 0x321a:
+                self.data['CodingEquations'] = reverse_auid(decode_auid(data)) #0x321a
 
 @register_mxf_class
 class MXFMultipleDescriptor(MXFDescriptor):
@@ -617,8 +623,8 @@ class MXFCDCIDescriptor(MXFDescriptor):
         d['Length'].value = self.data.get('Length', 0)
 
         # optional
-        for key in ('FrameSampleSize', 'ResolutionID', 'Compression', 'VerticalSubsampling',
-                    'SampledWidth', 'SampledHeight', 'LinkedSlotID'):
+        for key in ('FrameSampleSize', 'ResolutionID', 'Compression', 'VerticalSubsampling', 'TransferCharacteristic',
+                    'ColorPrimaries', 'CodingEquations', 'SampledWidth', 'SampledHeight', 'LinkedSlotID'):
             if key in self.data:
                 d[key].value = self.data[key]
 

--- a/src/aaf2/types.py
+++ b/src/aaf2/types.py
@@ -849,7 +849,8 @@ class TypeDefExtEnum(TypeDef):
                 if value.lower() == data.lower():
                     return key.bytes_le
 
-        raise ValueError("invalid ext enum value: %s" % str(data))
+        return data.bytes_le #emcodem: tolerate unknown ext enum AUIDs (e.g. Sony/ARRI colorspaces) and forward the raw value instead of raising
+        #raise ValueError("invalid ext enum value: %s" % str(data))
 
 @register_class
 class TypeDefIndirect(TypeDef):

--- a/src/aaf2/video.py
+++ b/src/aaf2/video.py
@@ -149,6 +149,17 @@ dnx_compression_auids = {
 
 }
 
+compression_ids_hevc = {
+    'HEVC_Video'                                    : AUID('04010202-0140-0000-060e-2b340401010d'),
+    'HEVC_MainProfile'                              : AUID('04010202-0141-0000-060e-2b340401010d'),
+    'HEVC_MainProfile_Unconstrained'                : AUID('04010202-0141-1001-060e-2b340401010d'),
+    'HEVC_Main10Profile'                            : AUID('04010202-0141-2000-060e-2b340401010d'),
+    'HEVC_Main10Profile_Unconstrained'              : AUID('04010202-0141-2001-060e-2b340401010d'),
+    'HEVC_Main422Profile'                           : AUID('04010202-0142-0000-060e-2b340401010d'),
+    'HEVC_Main422Profile_Unconstrained'             : AUID('04010202-0142-2001-060e-2b340401010d'),
+    'HEVC_Main44416IntraProfile_Unconstrained'      : AUID('04010202-0146-5001-060e-2b340401010d'),
+}
+
 compression_ids = {
 'CompressedPicture'                   : AUID('04010202-0000-0000-060e-2b3404010101'),
 'AVCBaselineUnconstrained'            : AUID('04010202-0131-1001-060e-2b340401010d'),


### PR DESCRIPTION
Sorry for sending all in one but you know how it is once you work on your own branch.. i'm still no git master unfortunately. 

- HEVC should be straight forward, check the reversed uls on https://emcodem.github.io/smpte-ul-search/ ;)
- robust ama_path handling for Windows: not sure how you could live without this
- TransferCharacteristic: seems also pretty straight forward
- Descriptor linking robustness: should probably have sent in multiple pieces, it was important for me to forward existing locator
- do not clutter: not functional change but it felt a bit strange that all of this was just dumped to stdout originally, did i miss some way to turn that off? 
- support forwarding unknown: it was important for me to forward unknown color metadata, not sure if this would break anything else but it feels right to do it this way
- prevent parse all klvs on non closed: very important addition, without this gigabytes of klv's are parsed if header is closedcomplete
- Prefers existing locator if the source mxf has one:  as the title says... if the source mxf has the locator already, we forward it